### PR TITLE
allow clipboard functionality prior to slider changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@
   'use strict';
 
   var clipboard = new Clipboard('.clipboardButton');
-  updateClipboardButtons();
 
   getAllGoogleFonts();
 
@@ -17,6 +16,7 @@
   webfont.style.fontSize = webfontOutput.style.fontSize = '16px';
   fallback.style.lineHeight = fallbackOutput.style.lineHeight = '28px';
   webfont.style.lineHeight = webfontOutput.style.lineHeight = '28px';
+  updateClipboardButtons();
 
   fallbackName.addEventListener('input', updateFontFamily);
   webfontName.addEventListener('input', updateFontFamily);


### PR DESCRIPTION
Currently unable to copy the clipboard until a change is made via the sliders. Calling updateClipboardButtons() after the initial webfont and fallback css has been set makes this possible. 

Not a big need to copy the initial css, but figured the functionality may as well work all the time!